### PR TITLE
feat: use async APIs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ axoupdater can also be used as a library within your own applications in order t
 To check for updates and notify the user:
 
 ```rust
-if AxoUpdater::new_for("axolotlsay").load_receipt()?.is_update_needed()? {
+if AxoUpdater::new_for("axolotlsay").load_receipt()?.is_update_needed_sync()? {
     eprintln!("axolotlsay is outdated; please upgrade!");
 }
 ```
@@ -25,7 +25,17 @@ if AxoUpdater::new_for("axolotlsay").load_receipt()?.is_update_needed()? {
 To automatically perform an update if the program isn't up to date:
 
 ```rust
-if AxoUpdater::new_for("axolotlsay").load_receipt()?.run()? {
+if AxoUpdater::new_for("axolotlsay").load_receipt()?.run_sync()? {
+    eprintln!("Update installed!");
+} else {
+    eprintln!("axolotlsay already up to date");
+}
+```
+
+Asynchronous versions of `is_update_needed()` and `run()` are also provided:
+
+```rust
+if AxoUpdater::new_for("axolotlsay").load_receipt()?.run().await? {
     eprintln!("Update installed!");
 } else {
     eprintln!("axolotlsay already up to date");
@@ -47,7 +57,7 @@ To build as a standalone binary, follow these steps:
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0))
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or [opensource.org/licenses/MIT](https://opensource.org/licenses/MIT))
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or [apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0))
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or [opensource.org/licenses/MIT](https://opensource.org/licenses/MIT))
 
 at your option.

--- a/axoupdater-cli/Cargo.toml
+++ b/axoupdater-cli/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 axocli = "0.2.0"
-axoupdater = { version = "=0.1.0", path = "../axoupdater" }
+axoupdater = { version = "=0.1.0", path = "../axoupdater", features = ["blocking"] }
 
 # errors
 miette = "7.1.0"

--- a/axoupdater-cli/src/bin/axoupdater/main.rs
+++ b/axoupdater-cli/src/bin/axoupdater/main.rs
@@ -8,7 +8,7 @@ fn real_main(_cli: &CliApp<CliArgs>) -> Result<(), miette::Report> {
 
     if AxoUpdater::new_for_updater_executable()?
         .load_receipt()?
-        .run()?
+        .run_sync()?
     {
         eprintln!("New release installed!")
     } else {

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [features]
 default = ["axo_releases", "github_releases"]
 axo_releases = ["gazenot", "tokio"]
+blocking = ["tokio"]
 github_releases = ["reqwest"]
 
 [dependencies]
@@ -35,7 +36,6 @@ tokio = { version = "1.36.0", features = ["full"], optional = true }
 
 # github releases
 reqwest = { version = "0.11", default-features = false, features = [
-    "blocking",
     "rustls-tls",
     "json",
 ], optional = true }


### PR DESCRIPTION
Turns `run()` and `is_update_needed()` into asynchronous APIs by default, with synchronous APIs provided as alternatives.