### PR TITLE
fix: tokio dep is non-default

### DIFF
--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["axo_releases", "github_releases"]
-axo_releases = ["gazenot", "tokio"]
+axo_releases = ["gazenot"]
 blocking = ["tokio"]
 github_releases = ["reqwest"]
 
@@ -32,13 +32,15 @@ temp-dir = "0.1.12"
 
 # axo releases
 gazenot = { version = "0.3.0", features = ["client_lib"], optional = true }
-tokio = { version = "1.36.0", features = ["full"], optional = true }
 
 # github releases
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
     "json",
 ], optional = true }
+
+# blocking API
+tokio = { version = "1.36.0", features = ["full"], optional = true }
 
 # errors
 miette = "7.1.0"

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -136,6 +136,7 @@ impl AxoUpdater {
         Ok(current_version != release.version())
     }
 
+    #[cfg(feature = "blocking")]
     /// Identical to Axoupdater::is_update_needed(), but performed synchronously.
     pub fn is_update_needed_sync(&mut self) -> AxoupdateResult<bool> {
         tokio::runtime::Builder::new_current_thread()
@@ -220,6 +221,7 @@ impl AxoUpdater {
         Ok(true)
     }
 
+    #[cfg(feature = "blocking")]
     /// Identical to Axoupdater::run(), but performed synchronously.
     pub fn run_sync(&mut self) -> AxoupdateResult<bool> {
         tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Ensures it's no longer pulled in via gazenot/axo_releases.