### PR TITLE
feat: return version info on success

### DIFF
--- a/axoupdater-cli/src/bin/axoupdater/main.rs
+++ b/axoupdater-cli/src/bin/axoupdater/main.rs
@@ -6,11 +6,11 @@ struct CliArgs {}
 fn real_main(_cli: &CliApp<CliArgs>) -> Result<(), miette::Report> {
     eprintln!("Checking for updates...");
 
-    if AxoUpdater::new_for_updater_executable()?
+    if let Some(result) = AxoUpdater::new_for_updater_executable()?
         .load_receipt()?
         .run_sync()?
     {
-        eprintln!("New release installed!")
+        eprintln!("New release {} installed!", result.new_version)
     } else {
         eprintln!("Already up to date; not upgrading");
     }


### PR DESCRIPTION
Returns old and new version info, plus the tag the new verson was built from.

Fixes #33.