### PR TITLE
Preserve reqwest error for the releases page

### DIFF
--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -931,10 +931,7 @@ async fn get_specific_github_version(
 }
 
 #[cfg(feature = "github_releases")]
-async fn get_releases(
-    client: &reqwest::Client,
-    url: &str,
-) -> AxoupdateResult<reqwest::Response> {
+async fn get_releases(client: &reqwest::Client, url: &str) -> AxoupdateResult<reqwest::Response> {
     Ok(client
         .get(url)
         .header(ACCEPT, "application/json")

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -934,10 +934,8 @@ async fn get_specific_github_version(
 async fn get_releases(
     client: &reqwest::Client,
     url: &str,
-    name: &str,
-    app_name: &str,
 ) -> AxoupdateResult<reqwest::Response> {
-    client
+    Ok(client
         .get(url)
         .header(ACCEPT, "application/json")
         .header(
@@ -947,11 +945,7 @@ async fn get_releases(
         .header("X-GitHub-Api-Version", "2022-11-28")
         .send()
         .await?
-        .error_for_status()
-        .map_err(|_| AxoupdateError::ReleaseNotFound {
-            name: name.to_owned(),
-            app_name: app_name.to_owned(),
-        })
+        .error_for_status()?)
 }
 
 // The format of the header looks like so:
@@ -987,7 +981,7 @@ async fn get_github_releases(
     let mut data: Vec<Release> = vec![];
 
     while pages_remain {
-        let resp = get_releases(&client, &url, name, app_name).await?;
+        let resp = get_releases(&client, &url).await?;
 
         let headers = resp.headers();
         let link_header = &headers[reqwest::header::LINK]


### PR DESCRIPTION
Previously, a github api status error for the github releases page would show a confusing error message in uv:

```
$ uv self update
info: Checking for updates...
error: No releases were found for the app uv in workspace uv
```

I've tested this by manually updating the receipt to a non-existent repo:

```
$ uv self update
info: Checking for updates...
error: HTTP status client error (404 Not Found) for url (https://api.github.com/repos/astral-sh-borken/uv/releases)
```

Fixes #79