### PR TITLE
feat: manually configure release source

### DIFF
--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -148,6 +148,16 @@ impl AxoUpdater {
         })
     }
 
+    /// Explicitly configures the release source as an alternative to
+    /// reading it from the install receipt. This can be useful for tasks
+    /// which want to query the new version without actually performing an
+    /// upgrade.
+    pub fn set_release_source(&mut self, source: ReleaseSource) -> &mut AxoUpdater {
+        self.source = Some(source);
+
+        self
+    }
+
     /// Attempts to load an install receipt in order to prepare for an update.
     /// If present and valid, the install receipt is used to populate the
     /// `source` and `current_version` fields.


### PR DESCRIPTION
Similar to the existing `set_version` method, this allows configuring the release source without reading it from a receipt. While the receipt is still necessary for actually performing the update, since it contains the install info we need to compare to, configuring the release source this way makes it possible to query for the latest version without loading a receipt.