### PR TITLE
feat: allow configuring tokens to fetch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     env:
       # runtest the installer scripts
       RUIN_MY_COMPUTER_WITH_INSTALLERS: true
+      AXOUPDATER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Test the cross-product of these platforms+toolchains
       matrix:

--- a/axoupdater-cli/src/bin/axoupdater/main.rs
+++ b/axoupdater-cli/src/bin/axoupdater/main.rs
@@ -30,6 +30,10 @@ fn real_main(cli: &CliApp<CliArgs>) -> Result<(), miette::Report> {
     let mut updater = AxoUpdater::new_for_updater_executable()?;
     updater.load_receipt()?;
 
+    if let Ok(token) = std::env::var("AXOUPDATER_GITHUB_TOKEN") {
+        updater.set_github_token(&token);
+    }
+
     let specifier = if let Some(tag) = &cli.config.tag {
         axoupdater::UpdateRequest::SpecificTag(tag.clone())
     } else if let Some(version) = &cli.config.version {

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -54,6 +54,12 @@ pub enum UpdateRequest {
     SpecificTag(String),
 }
 
+#[derive(Default)]
+pub(crate) struct AuthorizationTokens {
+    github: Option<String>,
+    axodotdev: Option<String>,
+}
+
 /// Struct representing an updater process
 pub struct AxoUpdater {
     /// The name of the program to update, if specified
@@ -75,6 +81,9 @@ pub struct AxoUpdater {
     /// The path to the installer to use for the new version.
     /// If not specified, downloads the installer from the release source.
     installer_path: Option<Utf8PathBuf>,
+    /// A token to use to query releases from GitHub. If not supplied,
+    /// AxoUpdater will perform unauthorized requests.
+    tokens: AuthorizationTokens,
 }
 
 impl Default for AxoUpdater {
@@ -98,6 +107,7 @@ impl AxoUpdater {
             print_installer_stdout: true,
             print_installer_stderr: true,
             installer_path: None,
+            tokens: AuthorizationTokens::default(),
         }
     }
 
@@ -113,6 +123,7 @@ impl AxoUpdater {
             print_installer_stdout: true,
             print_installer_stderr: true,
             installer_path: None,
+            tokens: AuthorizationTokens::default(),
         }
     }
 
@@ -139,6 +150,7 @@ impl AxoUpdater {
             print_installer_stdout: true,
             print_installer_stderr: true,
             installer_path: None,
+            tokens: AuthorizationTokens::default(),
         })
     }
 


### PR DESCRIPTION
These allow performing authorized requests with a higher rate limit, and which can access private repositories. The main intended usecase right now is our own tests, since they have a highly artificial environment where we run into rate limits more often than real-world users would.