### PR TITLE
feat: tighten up `bin` subdir handling

### DIFF
--- a/axoupdater/src/receipt.rs
+++ b/axoupdater/src/receipt.rs
@@ -20,6 +20,17 @@ pub struct InstallReceipt {
     pub source: ReleaseSource,
     /// Installed version
     pub version: String,
+    /// Information about the tool used to produce this receipt
+    pub provider: ReceiptProvider,
+}
+
+/// Tool used to produce this install receipt
+#[derive(Clone, Debug, Deserialize)]
+pub struct ReceiptProvider {
+    /// The name of the tool used to create this receipt
+    pub source: String,
+    /// The version of the above tool
+    pub version: String,
 }
 
 impl AxoUpdater {
@@ -37,6 +48,13 @@ impl AxoUpdater {
 
         self.source = Some(receipt.source);
         self.current_version = Some(receipt.version.parse::<Version>()?);
+
+        let provider = crate::Provider {
+            source: receipt.provider.source,
+            version: receipt.provider.version.parse::<Version>()?,
+        };
+
+        self.current_version_installed_by = Some(provider);
         self.install_prefix = Some(receipt.install_prefix);
 
         Ok(self)


### PR DESCRIPTION
We currently strip a trailing `/bin` directory in several places. This was done to work around a bug that shipped in cargo-dist between 0.10.0 and 0.12.0, where the prefix was always set to the `bin` directory instead of the actual install path. This was introduced in https://github.com/axodotdev/cargo-dist/commit/91ac6af587cf221b62d56c98cf99fb169c449011, which first shipped in 0.10.0, and finally eliminated in the install path rewrite that shipped in 0.12.0.

Always doing this actually introduced a few bugs of its own, so this now works around it by actually checking the version of the cargo-dist that produced the install receipt and only applying the correction if that version is within the 0.10.0 to pre-0.12.0 range. Luckily, we always included cargo-dist install info in the receipt from the very first commit that introduced receipts, even though we weren't reading them until now, so we're always able to perform this check.

Fixes #108.