### PR TITLE
fix: avoid possible file rename across filesystem bounds on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "miette",
  "reqwest",
  "serde",
- "temp-dir",
+ "tempfile",
  "thiserror",
  "tokio",
 ]
@@ -202,7 +202,7 @@ dependencies = [
  "clap",
  "miette",
  "reqwest",
- "temp-dir",
+ "tempfile",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "pin-project",
  "tokio",
@@ -547,6 +547,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "filetime"
@@ -969,9 +975,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1347,9 +1353,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -1675,10 +1681,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "temp-dir"
-version = "0.1.13"
+name = "tempfile"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand 2.1.0",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "terminal_size"

--- a/axoupdater-cli/Cargo.toml
+++ b/axoupdater-cli/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = ">=0.11.0", default-features = false, features = [
     "blocking",
     "rustls-tls",
 ] }
-temp-dir = "0.1.13"
+tempfile = "3.10.1"
 
 [[bin]]
 name = "axoupdater"

--- a/axoupdater-cli/tests/integration.rs
+++ b/axoupdater-cli/tests/integration.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use axoasset::LocalAsset;
 use axoprocess::Cmd;
 use camino::{Utf8Path, Utf8PathBuf};
-use temp_dir::TempDir;
+use tempfile::TempDir;
 
 static BIN: &str = env!("CARGO_BIN_EXE_axoupdater");
 static RECEIPT_TEMPLATE: &str = r#"{"binaries":["axolotlsay"],"install_prefix":"INSTALL_PREFIX","provider":{"source":"cargo-dist","version":"CARGO_DIST_VERSION"},"source":{"app_name":"axolotlsay","name":"cargodisttest","owner":"mistydemeo","release_type":"github"},"version":"VERSION"}"#;

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -25,7 +25,7 @@ axotag = { version = "0.2.0" }
 camino = { version = "1.1.6", features = ["serde1"] }
 homedir = "0.2.1"
 serde = "1.0.197"
-temp-dir = "0.1.13"
+tempfile = "3.10.1"
 
 # axo releases
 gazenot = { version = "0.3.1", features = ["client_lib"], optional = true }

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -448,7 +448,20 @@ impl AxoUpdater {
         // NOTE: this TempDir needs to be held alive for the whole function.
         let temp_root;
         let to_restore = if cfg!(target_family = "windows") {
-            temp_root = TempDir::new()?;
+            // If we know the install prefix, place the temporary directory for
+            // the executable there. This is because the `rename` syscall can't
+            // rename an executable across filesystem bounds, and there's a
+            // chance the system temporary directory could be on a different
+            // drive than the executable is.
+            // (A copy-and-delete move won't work because Windows won't let us
+            // delete a running executable - the same reason we're moving it out
+            // of the way to begin with!)
+            // See https://github.com/axodotdev/axoupdater/issues/120.
+            temp_root = if let Ok(prefix) = self.install_prefix_root() {
+                TempDir::new_in(prefix)?
+            } else {
+                TempDir::new()?
+            };
             let old_path = std::env::current_exe()?;
             let old_filename = old_path.file_name().expect("current binary has no name!?");
             let ourselves = temp_root.path().join(old_filename);

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -24,7 +24,7 @@ use axoprocess::Cmd;
 pub use axotag::Version;
 use camino::Utf8PathBuf;
 
-use temp_dir::TempDir;
+use tempfile::TempDir;
 
 /// Provides information about the result of the upgrade operation
 pub struct UpdateResult {


### PR DESCRIPTION
It's possible for the Windows tempdir to be on a different drive than the currently running EXE, which makes `rename()` impossible. In case that happens to us, we should handle it by creating the temp path to rename the Windows exe to inside the install prefix, a path that we should be able to trust to be a) writable to us, and b) on the same drive as the EXE itself.

If we don't know the install_prefix, fall back to the old behaviour of creating a temporary directory inside the system temp dir.

I had to migrate us to a different tempdir library to handle this, since `temp-dir` doesn't support creating temporary directories anywhere other than the system tmpdir.

Fixes #120.