### PR TITLE
chore: axoasset 0.10.1, gazenot 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,19 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,9 +99,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axoasset"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d492e2a60fbacf2154ee58fd4bc3dd7385a5febf10fef6145924fd3117cd920"
+checksum = "324ff9901b842d132aad26d113d5ecbed193a97ea263dfe531296b026de9ff80"
 dependencies = [
  "camino",
  "flate2",
@@ -568,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -682,15 +669,14 @@ dependencies = [
 
 [[package]]
 name = "gazenot"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f72c27df37233564f3050f767b1b77fff511143c7428a64b929f279b7a558"
+checksum = "77c01a17924566e445bdf7499f23c0910e8ebe6c34dffd8a72ebdaa81395c3a7"
 dependencies = [
  "axoasset",
  "backon",
  "camino",
  "miette",
- "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -1294,7 +1280,6 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1321,7 +1306,6 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1489,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1978,9 +1962,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/axoupdater-cli/Cargo.toml
+++ b/axoupdater-cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4.5.7", features = ["derive"] }
 miette = "7.2.0"
 
 [dev-dependencies]
-axoasset = { version = "0.9.3", default-features = false, features = [
+axoasset = { version = "0.10.1", default-features = false, features = [
     "compression", "compression-tar", "compression-zip"
 ] }
 axoprocess = "0.2.0"

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -17,7 +17,7 @@ blocking = ["tokio"]
 github_releases = ["reqwest"]
 
 [dependencies]
-axoasset = { version = ">= 0.9.0, < 0.10.0", default-features = false, features = [
+axoasset = { version = ">= 0.9.0, < 0.11.0", default-features = false, features = [
     "json-serde",
 ] }
 axoprocess = "0.2.0"
@@ -28,7 +28,7 @@ serde = "1.0.197"
 tempfile = "3.10.1"
 
 # axo releases
-gazenot = { version = "0.3.1", features = ["client_lib"], optional = true }
+gazenot = { version = "0.3.2", features = ["client_lib"], optional = true }
 
 # github releases
 reqwest = { version = ">=0.11.0", default-features = false, features = [


### PR DESCRIPTION
Updates axoasset and gazenot together since gazenot itself depends on axoasset, and this lets us update to a single version in-tree.