### PR TITLE
feat: return stdout/stderr from installers if able

### DIFF
--- a/axoupdater/src/errors.rs
+++ b/axoupdater/src/errors.rs
@@ -146,4 +146,17 @@ pub enum AxoupdateError {
         /// The name of the missing field
         missing_field: String,
     },
+
+    /// Indicates the installation failed for some reason we're not sure of
+    #[error("The installation failed. Output from the installer: {}\n{}", stdout.clone().unwrap_or_default(), stderr.clone().unwrap_or_default())]
+    InstallFailed {
+        /// The status code from the underlying process, if any
+        status: Option<i32>,
+        /// The stdout, decoded to UTF-8. This will be None if it was piped
+        /// to the terminal when running the installer.
+        stdout: Option<String>,
+        /// The stderr, decoded to UTF-8. This will be None if it was piped
+        /// to the terminal when running the installer.
+        stderr: Option<String>,
+    },
 }


### PR DESCRIPTION
We print the stdout/stderr to the terminal by default, but if the caller has requested us to turn that off, we were instead throwing that output away. This now instead copies that output to the error type in the case that we didn't print it to the terminal, allowing the caller to try to do something with it.

I was undecided on whether we wanted to decode the strings before passing them on, or if we should just pass along the raw bytes we get from the process call.