### PR TITLE
feat: use self_replace to delete self

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "gazenot",
  "homedir",
  "miette",
+ "self-replace",
  "serde",
  "tempfile",
  "thiserror",
@@ -1425,6 +1426,17 @@ checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand 2.1.0",
+ "tempfile",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -35,3 +35,6 @@ tokio = { version = "1.36.0", features = ["full"], optional = true }
 # errors
 miette = "7.2.0"
 thiserror = "1.0.58"
+
+[target.'cfg(windows)'.dependencies]
+self-replace = "1.5.0"

--- a/axoupdater/src/errors.rs
+++ b/axoupdater/src/errors.rs
@@ -159,4 +159,11 @@ pub enum AxoupdateError {
         /// to the terminal when running the installer.
         stderr: Option<String>,
     },
+
+    /// self_replace/self_delete failed
+    #[error(
+        "Cleaning up the previous version failed; a copy of the old version has been left behind."
+    )]
+    #[diagnostic(help("This probably isn't your fault; please open an issue at https://github.com/axodotdev/axoupdater!"))]
+    CleanupFailed {},
 }


### PR DESCRIPTION
This is an attempt at handling https://github.com/axodotdev/cargo-dist/issues/1374 using the [self-replace crate](https://github.com/mitsuhiko/self-replace). We leave the existing Unix behaviour in place, since it's already safe, but it replaces the previous Windows version with a new one: the Windows EXE is given a specific temporary name and, if the upgrade succeeded, we then set a flag to ensure it's deleted once the process completes.

Appears to be working on Windows but needs more testing.