### PR TITLE
feat: avoid modifying path if inappropriate

### DIFF
--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -97,6 +97,8 @@ pub struct AxoUpdater {
     /// When set to true, skips performing version checks and always assumes
     /// the software is out of date.
     always_update: bool,
+    /// Whether to modify the system path when installing
+    modify_path: bool,
 }
 
 impl Default for AxoUpdater {
@@ -123,6 +125,7 @@ impl AxoUpdater {
             installer_path: None,
             tokens: AuthorizationTokens::default(),
             always_update: false,
+            modify_path: true,
         }
     }
 
@@ -141,6 +144,7 @@ impl AxoUpdater {
             installer_path: None,
             tokens: AuthorizationTokens::default(),
             always_update: false,
+            modify_path: true,
         }
     }
 
@@ -170,6 +174,7 @@ impl AxoUpdater {
             installer_path: None,
             tokens: AuthorizationTokens::default(),
             always_update: false,
+            modify_path: true,
         })
     }
 
@@ -517,8 +522,15 @@ impl AxoUpdater {
         // Also set the app-specific name for this; in the future, the
         // CARGO_DIST_ version may be removed.
         let app_name = self.name.clone().unwrap_or_default();
-        let app_specific_env_var = app_name.to_ascii_uppercase().replace('-', "_") + "_INSTALL_DIR";
+        let app_name_env_var = app_name.to_ascii_uppercase().replace('-', "_");
+        let app_specific_env_var = format!("{app_name_env_var}_INSTALL_DIR");
         command.env(app_specific_env_var, &install_prefix);
+
+        // If the previous installation didn't modify the path, we shouldn't either
+        if !self.modify_path {
+            let app_specific_modify_path = format!("{app_name_env_var}_NO_MODIFY_PATH");
+            command.env(app_specific_modify_path, "1");
+        }
 
         let result = command.output();
 

--- a/axoupdater/src/receipt.rs
+++ b/axoupdater/src/receipt.rs
@@ -9,6 +9,10 @@ use axotag::Version;
 use camino::Utf8PathBuf;
 use serde::Deserialize;
 
+fn default_as_true() -> bool {
+    true
+}
+
 /// Information parsed from a cargo-dist install receipt
 #[derive(Clone, Debug, Deserialize)]
 pub struct InstallReceipt {
@@ -26,6 +30,10 @@ pub struct InstallReceipt {
     pub version: String,
     /// Information about the tool used to produce this receipt
     pub provider: ReceiptProvider,
+    /// Information about whether new installations should modify system paths
+    // Added in cargo-dist 0.23.0, missing in older receipts
+    #[serde(default = "default_as_true")]
+    pub modify_path: bool,
 }
 
 /// Tool used to produce this install receipt
@@ -60,6 +68,7 @@ impl AxoUpdater {
 
         self.current_version_installed_by = Some(provider);
         self.install_prefix = Some(receipt.install_prefix);
+        self.modify_path = receipt.modify_path;
 
         Ok(self)
     }


### PR DESCRIPTION
If the original installation was done via `APP_NAME_NO_MODIFY_PATH`, we should make sure the new installation does the same thing.

Fixes https://github.com/astral-sh/uv/issues/7319.
Fixes https://github.com/astral-sh/uv/issues/5576.
Fixes #174.