### PR TITLE
feat: use new custom env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -2739,9 +2740,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -25,6 +25,7 @@ camino = { version = "1.1.6", features = ["serde1"] }
 homedir = "0.3.3"
 serde = "1.0.197"
 tempfile = "3.10.1"
+url = "2.5.2"
 
 # axo releases
 gazenot = { version = "0.3.3", features = ["client_lib"], optional = true }

--- a/axoupdater/src/errors.rs
+++ b/axoupdater/src/errors.rs
@@ -46,6 +46,10 @@ pub enum AxoupdateError {
     #[error(transparent)]
     Version(#[from] axotag::semver::Error),
 
+    /// Failed to parse a URL
+    #[error(transparent)]
+    UrlParseError(#[from] url::ParseError),
+
     /// Failure when converting a PathBuf to a Utf8PathBuf
     #[error("An internal error occurred when decoding path `{:?}' to utf8", path)]
     #[diagnostic(help("This probably isn't your fault; please open an issue!"))]
@@ -166,4 +170,26 @@ pub enum AxoupdateError {
     )]
     #[diagnostic(help("This probably isn't your fault; please open an issue at https://github.com/axodotdev/axoupdater!"))]
     CleanupFailed {},
+
+    /// User passed conflicting GitHub API environment variables
+    #[error("Both {ghe_env_var} and {github_env_var} have been set in the environment")]
+    #[diagnostic(help("These variables are mutually exclusive; please pick one."))]
+    MultipleGitHubAPIs {
+        /// The GitHub Enterprise env var
+        ghe_env_var: String,
+        /// The GitHub env var
+        github_env_var: String,
+    },
+
+    /// Couldn't parse the text domain (could be an IP, etc.)
+    #[error("Unable to parse the domain from the passed url: {url}")]
+    #[diagnostic(help("The {env_var} variable only takes domains. If you're using an IP, we recommend the GitHub Enterprise-style variable: {ghe_env_var}"))]
+    GitHubDomainParseError {
+        /// The GitHub env var
+        env_var: String,
+        /// The GitHub Enterprise env var
+        ghe_env_var: String,
+        /// The supplied URL
+        url: String,
+    },
 }

--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -512,7 +512,7 @@ impl AxoUpdater {
         // Also set the app-specific name for this; in the future, the
         // CARGO_DIST_ version may be removed.
         let app_name = self.name.clone().unwrap_or_default();
-        let app_name_env_var = app_name.to_ascii_uppercase().replace('-', "_");
+        let app_name_env_var = app_name_to_env_var(&app_name);
         let app_specific_env_var = format!("{app_name_env_var}_INSTALL_DIR");
         command.env(app_specific_env_var, &install_prefix);
 
@@ -619,6 +619,11 @@ fn get_app_name() -> Option<String> {
     } else {
         None
     }
+}
+
+/// Returns an environment variable-compatible version of the app name.
+pub fn app_name_to_env_var(app_name: &str) -> String {
+    app_name.to_ascii_uppercase().replace('-', "_")
 }
 
 fn root_without_bin(path: &Utf8PathBuf) -> Utf8PathBuf {


### PR DESCRIPTION
These two new environment variables are defined for compatibility with cargo-dist, which uses the same variables in its installers: https://github.com/axodotdev/cargo-dist/pull/1503