### PR TITLE
Make `AxoUpdater::install_prefix_root` public

### DIFF
--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -351,7 +351,7 @@ impl AxoUpdater {
     /// component if necessary. Works around a bug introduced in cargo-dist
     /// where this field was returned inconsistently in receipts for a few
     /// versions.
-    fn install_prefix_root(&self) -> AxoupdateResult<Utf8PathBuf> {
+    pub fn install_prefix_root(&self) -> AxoupdateResult<Utf8PathBuf> {
         let Some(install_prefix) = &self.install_prefix else {
             return Err(AxoupdateError::NotConfigured {
                 missing_field: "install_prefix".to_owned(),


### PR DESCRIPTION
We need access to this (or similar) to avoid confusion, e.g., https://github.com/astral-sh/uv/issues/6774#issuecomment-2504950681, when the receipt is for a different uv executable. See https://github.com/astral-sh/uv/pull/9487, which uses this change to power a message like:

```
❯ cargo run --all-features -q -- self update
warning: Self-update is only available for uv binaries installed via the standalone installation scripts.

The current executable is at `/Users/zb/workspace/uv/target/debug/uv` but the standalone installer was used to install uv to `/Users/zb/.cargo`. Are multiple copies of uv installed?
```