### PR TITLE
feat: allow loading alternate receipts

### DIFF
--- a/axoupdater/src/lib.rs
+++ b/axoupdater/src/lib.rs
@@ -202,6 +202,19 @@ impl AxoUpdater {
         Ok(self)
     }
 
+    /// Changes this updater's name to `app_name`, regardless of what it was
+    /// initialized as and regardless of what was read from the receipt.
+    pub fn set_name(&mut self, app_name: &str) -> &mut AxoUpdater {
+        self.name = Some(app_name.to_owned());
+        if let Some(source) = &self.source {
+            let mut our_source = source.clone();
+            our_source.app_name = app_name.to_owned();
+            self.source = Some(our_source);
+        }
+
+        self
+    }
+
     /// Enables printing the underlying installer's stdout.
     pub fn enable_installer_stdout(&mut self) -> &mut AxoUpdater {
         self.print_installer_stdout = true;

--- a/axoupdater/src/receipt.rs
+++ b/axoupdater/src/receipt.rs
@@ -52,10 +52,18 @@ impl AxoUpdater {
     /// Shell and Powershell installers produced by cargo-dist since 0.9.0
     /// will have created an install receipt.
     pub fn load_receipt(&mut self) -> AxoupdateResult<&mut AxoUpdater> {
-        let Some(app_name) = &self.name else {
+        let Some(app_name) = self.name.clone() else {
             return Err(AxoupdateError::NoAppNamePassed {});
         };
 
+        self.load_receipt_as(&app_name)
+    }
+
+    /// Similar to `AxoUpdater::load_receipt`, but loads a receipt for the app
+    /// with the name `app_name` instead of the auto-detected name. This can be
+    /// useful if the receipt may exist under several different names, for
+    /// example if an app has been renamed.
+    pub fn load_receipt_as(&mut self, app_name: &str) -> AxoupdateResult<&mut AxoUpdater> {
         let receipt = load_receipt_for(app_name)?;
 
         self.source = Some(receipt.source);


### PR DESCRIPTION
This allows loading receipts that may exist under alternate app names. This is most useful if an app may have been renamed, and the older/newer versions use different naems from each other.

`load_receipt_as` doesn't change the internal name for the app, so it's safe to call multiple times with different names.

Edit: added a second method to make it possible to override the name that was parsed from a receipt.