### PR TITLE
chore: add additional arm targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "arm-unknown-linux-gnueabihf", "armv7-unknown-linux-gnueabihf", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc", "armv7-unknown-linux-gnueabi"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Publish jobs to run in CI


### PR DESCRIPTION
Add additional ARM targets to generate prebuilts since cargo-dist currently does not support building from source:

    * arm-unknown-linux-gnueabihf
    * armv7-unknown-linux-gnueabi
    * armv7-unknown-linux-gnueabihf

Fixes #313 