### PR TITLE
fix: ensure exec staging dir, preferring user dirs over tmp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,11 @@ dependencies = [
  "axoprocess",
  "axotag",
  "camino",
+ "directories",
  "gazenot",
  "homedir",
  "httpmock",
+ "libc",
  "miette",
  "self-replace",
  "serde",
@@ -546,6 +548,27 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1269,6 +1292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1484,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -1676,6 +1715,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2277,7 +2327,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/axoupdater-cli/tests/integration.rs
+++ b/axoupdater-cli/tests/integration.rs
@@ -58,6 +58,16 @@ fn write_receipt(
     Ok(())
 }
 
+fn executable_tempdir() -> std::io::Result<TempDir> {
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        tempfile::Builder::new()
+            .prefix("axoupdater-exec")
+            .tempdir_in(runtime_dir)
+    } else {
+        TempDir::new()
+    }
+}
+
 #[test]
 fn bails_out_with_default_name() {
     let mut command = Cmd::new(BIN, "execute axoupdater");
@@ -81,7 +91,7 @@ fn bails_out_with_default_name() {
 //       several noteworthy bugfixes in its installer.
 #[test]
 fn test_upgrade() -> std::io::Result<()> {
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
@@ -144,7 +154,7 @@ fn test_upgrade() -> std::io::Result<()> {
 
 #[test]
 fn test_upgrade_xdg_config_home() -> std::io::Result<()> {
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
@@ -209,7 +219,7 @@ fn test_upgrade_xdg_config_home() -> std::io::Result<()> {
 
 #[test]
 fn test_upgrade_allow_prerelease() -> std::io::Result<()> {
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
@@ -276,7 +286,8 @@ fn test_upgrade_allow_prerelease() -> std::io::Result<()> {
 #[test]
 fn test_upgrade_to_specific_version() -> std::io::Result<()> {
     let tempdir = TempDir::new()?;
-    let bindir_path = &tempdir.path().join("bin");
+    let executable_tmp = executable_tempdir()?;
+    let bindir_path = &executable_tmp.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
 
@@ -334,7 +345,7 @@ fn test_upgrade_to_specific_version() -> std::io::Result<()> {
 // version on request instead of upgrading.
 #[test]
 fn test_downgrade_to_specific_version() -> std::io::Result<()> {
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
@@ -406,7 +417,7 @@ fn test_downgrade_to_specific_old_version() -> std::io::Result<()> {
         _ => return Ok(()),
     }
 
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();
     std::fs::create_dir_all(bindir)?;
@@ -469,7 +480,7 @@ fn test_downgrade_to_specific_old_version() -> std::io::Result<()> {
 // https://github.com/axodotdev/cargo-dist/pull/1037
 #[test]
 fn test_upgrade_from_prefix_with_no_bin() -> std::io::Result<()> {
-    let tempdir = TempDir::new()?;
+    let tempdir = executable_tempdir()?;
     let prefix = Utf8PathBuf::from_path_buf(tempdir.path().to_path_buf()).unwrap();
     let bindir_path = &tempdir.path().join("bin");
     let bindir = Utf8Path::from_path(bindir_path).unwrap();

--- a/axoupdater/Cargo.toml
+++ b/axoupdater/Cargo.toml
@@ -36,9 +36,13 @@ tokio = { version = "1.48.0", features = ["full"], optional = true }
 # errors
 miette = "7.2.0"
 thiserror = "2.0.0"
+directories = "6.0.0"
 
 [target.'cfg(windows)'.dependencies]
 self-replace = "1.5.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.48.0", features = ["test-util"] }

--- a/axoupdater/src/staging_dir.rs
+++ b/axoupdater/src/staging_dir.rs
@@ -1,0 +1,189 @@
+//! Installer staging directory selection and lifecycle helpers.
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+
+#[cfg(unix)]
+use std::{os::unix::fs::PermissionsExt, process::Command};
+
+use directories::BaseDirs;
+use tempfile::TempDir;
+
+use crate::errors::AxoupdateResult;
+
+/// Selects an executable staging tempdir for installer downloads.
+///
+/// Tries runtime/cache/data-local roots first, then falls back to the
+/// process-global temporary directory.
+pub(crate) fn select_installer_tempdir(parent_name: &str) -> AxoupdateResult<TempDir> {
+    let name_prefix = tempdir_name_prefix(parent_name);
+    for candidate in prioritized_staging_roots() {
+        if let Ok(tempdir) = tempfile::Builder::new()
+            .prefix(&name_prefix)
+            .tempdir_in(candidate)
+        {
+            if can_execute_from_dir(tempdir.path()) {
+                return Ok(tempdir);
+            }
+        }
+    }
+
+    let tempdir = TempDir::new()?;
+    if can_execute_from_dir(tempdir.path()) {
+        Ok(tempdir)
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "unable to find an executable temp directory",
+        )
+        .into())
+    }
+}
+
+fn prioritized_staging_roots() -> Vec<PathBuf> {
+    let Some(base_dirs) = BaseDirs::new() else {
+        return Vec::new();
+    };
+
+    let mut dirs = Vec::new();
+
+    if let Some(runtime_dir) = runtime_dir_with_unix_fallback(&base_dirs) {
+        // On Linux, XDG says runtime dir "must" exist, be user owned, user-session scoped,
+        // and be 700 (i.e. executable). Generally seems most appropriate.
+        dirs.push(runtime_dir);
+    }
+    dirs.push(base_dirs.cache_dir().to_path_buf());
+    dirs.push(base_dirs.data_local_dir().to_path_buf());
+
+    dirs
+}
+
+fn tempdir_name_prefix(parent_name: &str) -> String {
+    format!("{}-axoupdate-", sanitized_parent_component(parent_name))
+}
+
+fn sanitized_parent_component(parent_name: &str) -> String {
+    let mut safe = parent_name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if safe.is_empty() || safe.chars().all(|ch| ch == '.') {
+        safe = "axoupdater".to_owned();
+    }
+    safe
+}
+
+fn runtime_dir_with_unix_fallback(base_dirs: &BaseDirs) -> Option<PathBuf> {
+    if let Some(runtime_dir) = base_dirs.runtime_dir() {
+        return Some(runtime_dir.to_path_buf());
+    }
+
+    #[cfg(unix)]
+    {
+        if env::var_os("XDG_RUNTIME_DIR").is_none() {
+            let uid = unsafe { libc::geteuid() };
+            let fallback = PathBuf::from(format!("/run/user/{uid}"));
+            if fallback.is_dir() {
+                return Some(fallback);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(unix)]
+fn can_execute_from_dir(dir: &Path) -> bool {
+    let script_path = dir.join(format!("exec-probe-{}.sh", std::process::id()));
+    let script_contents = "#!/bin/sh\nexit 0\n";
+
+    if fs::write(&script_path, script_contents).is_err() {
+        return false;
+    }
+
+    let chmod_result = fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700));
+    if chmod_result.is_err() {
+        let _ = fs::remove_file(&script_path);
+        return false;
+    }
+
+    let ran = Command::new(&script_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
+
+    let _ = fs::remove_file(&script_path);
+    ran
+}
+
+#[cfg(not(unix))]
+fn can_execute_from_dir(dir: &Path) -> bool {
+    dir.is_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use directories::BaseDirs;
+
+    #[cfg(unix)]
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    use super::{
+        prioritized_staging_roots, runtime_dir_with_unix_fallback, sanitized_parent_component,
+        tempdir_name_prefix,
+    };
+
+    #[test]
+    fn test_staging_dir_priorities_follow_base_dirs_order() {
+        let Some(base_dirs) = BaseDirs::new() else {
+            return;
+        };
+        let mut expected = Vec::new();
+        if let Some(runtime_dir) = runtime_dir_with_unix_fallback(&base_dirs) {
+            expected.push(runtime_dir);
+        }
+        expected.push(base_dirs.cache_dir().to_path_buf());
+        expected.push(base_dirs.data_local_dir().to_path_buf());
+
+        let actual = prioritized_staging_roots();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_parent_component_is_sanitized() {
+        assert_eq!(
+            sanitized_parent_component("../parent/workspace"),
+            ".._parent_workspace"
+        );
+        assert_eq!(sanitized_parent_component(""), "axoupdater");
+    }
+
+    #[test]
+    fn test_tempdir_name_prefix_shape() {
+        assert_eq!(
+            tempdir_name_prefix("parent-workspace"),
+            "parent-workspace-axoupdate-".to_owned()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_can_execute_from_dir_detects_unusable_permissions() {
+        let parent = tempfile::tempdir().expect("parent tempdir");
+        let no_exec = parent.path().join("noexec");
+        fs::create_dir(&no_exec).expect("create test directory");
+        fs::set_permissions(&no_exec, fs::Permissions::from_mode(0o600)).expect("chmod test dir");
+
+        assert!(!super::can_execute_from_dir(&no_exec));
+    }
+}


### PR DESCRIPTION
Fixes #324 . Related to https://github.com/astral-sh/uv/issues/17191.

As a bit extra context for the issue, `/tmp` is sometimes mounted `noexec`, as it is I believe considered "security best practice" according to CIS. So probably, most users hit by this are enterprisy. But I suppose there might be some distros out there as well.

This PR handles the issue by:

1. Walking through a list of priorities, starting with runtime dir, cache dir and data-local dir (using `directories` crate that I added as dependency), and then finally TMPDIR at last as before.
2. For each one, if it exists and we can create a subfolder, it tests if it is possible to execute from there (assuming true on non-unix). This happens by writing a small no-op script.
    - _In practice_ we're going to mostly resolve `/run/user/<uid>` on Linux, `$HOME/Library/Caches` on MacOS, and `{FOLDERID_LocalAppData}` on Windows (as documented by the directories crate).
4. Still uses the `tempfile` library as before for cleanup on drop

I've tested this with a script that sets up a "fake root":

```bash
#!/bin/bash -eux

ROOT=/tmp/axo-staging-check
TMPDIR=$ROOT/tmp
XDG_RUNTIME_DIR=$ROOT/runtime
XDG_CACHE_HOME=$ROOT/cache
XDG_DATA_HOME=$ROOT/data

domount() {
	sudo mkdir -p $1
	sudo mount -t tmpfs -o rw,nosuid,nodev,size=512m,$2 tmpfs $1
}
domount $TMPDIR noexec,mode=777
domount $XDG_RUNTIME_DIR exec,mode=700,uid=$(id -u),gid=$(id -g)
domount $XDG_CACHE_HOME exec,mode=775,uid=$(id -u),gid=$(id -g)
domount $XDG_DATA_HOME exec,mode=775,uid=$(id -u),gid=$(id -g)

# Cargo will use our fake TMPDIR otherwise, filling it
cargo test --no-run
# Now run test
set +e
RUST_BACKTRACE=1 \
TMPDIR=$TMPDIR \
XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
XDG_CACHE_HOME=$XDG_CACHE_HOME \
XDG_DATA_HOME=$XDG_DATA_HOME \
cargo test -p axoupdater-cli --test integration test_upgrade -- --nocapture

# Do cleanup
# ls -la $TMPDIR $XDG_RUNTIME_DIR $XDG_CACHE_HOME $XDG_DATA_HOME
sudo umount $TMPDIR $XDG_RUNTIME_DIR $XDG_CACHE_HOME $XDG_DATA_HOME
```

Although it's not easy to run the tests due to rate limiting from Github. I also had to adapt the cli tests to have a fallback to the runtime dir themselves, as they each individually do the whole "download and execute" dance, which won't work with a noexec tmp either.